### PR TITLE
Rename OpenAPI specification file to match guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Linee guida generali per gli agenti
+
+Questa libreria PHP fornisce un SDK per le API della Veeam Service Provider Console (VSPC) versione 8.1. Il file OpenAPI ufficiale è disponibile in `openapi/3.5.1/vspc-api.json` ed è la fonte di verità per rotta, parametri e modelli di payload.
+
+## Come pianificare una modifica
+- Leggi sempre lo swagger prima di implementare nuovi metodi o payload: ogni classe del namespace `Repositories` mappa una "categoria" (tag) del file OpenAPI.
+- Verifica se la funzionalità esiste già: evita duplicati e mantieni i nomi dei metodi coerenti con lo standard esistente (`get…`, `post…`, `patch…`, `delete…`).
+- Se aggiungi nuove richieste ricordati di esporre un `RequestBuilder` pronto all'uso; l'esecuzione avviene tramite `VeeamSPCClient::jsonResponse()` o metodi analoghi.
+- Quando tocchi più aree, valuta se servono ulteriori AGENTS.md più specifici per documentare la scelta.
+
+## Struttura del codice
+- `src/Repositories`: classi che rappresentano i vari endpoint; usano i trait `Create*Request` per costruire l'oggetto `RequestBuilder`.
+- `src/Payloads`: classi fluenti che costruiscono il body delle richieste mutando lo stato interno e restituendo `self`.
+- `src/Support`: componenti riutilizzabili per query string, filtri e creazione delle richieste PSR-7.
+
+## Stile e qualità
+- Il progetto segue lo stile esistente (indentazione con tab, snake case nei path, camel case nelle proprietà private). Mantieni i docblock a supporto dei setter pubblici quando servono tipi misti.
+- Le nuove dipendenze devono essere aggiunte via Composer e documentate nel changelog del PR.
+- Non ci sono test automatici: se introduci nuove funzionalità fornisci esempi d'uso nel messaggio del PR o nel README.
+
+## Documentazione
+- Aggiorna il README solo se aggiungi funzionalità di alto livello (nuove repository, payload importanti, uso del client).
+- Se aggiungi nuove istruzioni operative, preferisci creare/aggiornare l'AGENTS.md più vicino alla modifica.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2023 Shellrent
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
-# veeam-vspc-api-client
-PHP Client for Veeam Service Provider Console API
+# Veeam Service Provider Console API Client
+
+A PHP SDK for integrating with the [Veeam Service Provider Console (VSPC)](https://www.veeam.com/service-provider-console.html) REST API. The library wraps the official OpenAPI specification provided with VSPC v8.1 and offers repositories, request builders, and payload helpers to quickly interact with the console from PHP applications and automation scripts.
+
+## Features
+- Guzzle-based HTTP client preconfigured for the VSPC REST endpoints.
+- Repository classes mirroring the API tags (Authentication, Companies, Backup Servers, and more).
+- Fluent payload builders to compose request bodies for complex operations.
+- Helpers for filters, pagination, and query parameters.
+- Returns PSR-7 responses or decoded JSON payloads for convenience.
+
+## Requirements
+- PHP ^8.1 with the JSON extension enabled.
+- Composer for dependency management.
+- Access to a VSPC environment (on-premises or hosted) with API credentials.
+
+## Installation
+Install the package via Composer:
+
+```bash
+composer require shellrent/veeam-vspc-api-client
+```
+
+## Getting Started
+Create an instance of the SDK by providing the base endpoint of your VSPC installation. The client accepts an optional bearer token and additional [Guzzle client options](https://docs.guzzlephp.org/en/stable/request-options.html).
+
+```php
+use Shellrent\VeeamVspcApiClient\VeeamSPCClient;
+
+$client = new VeeamSPCClient(
+    endpoint: 'https://vspc.example.com',
+    token: null,
+    options: [
+        // Any Guzzle option (timeouts, proxies, etc.)
+    ]
+);
+```
+
+### Authenticate and Fetch a Token
+Use the `AuthenticationRepository` with the `OAuthPayload` helper to request an access token.
+
+```php
+use Shellrent\VeeamVspcApiClient\Payloads\OAuthPayload;
+use Shellrent\VeeamVspcApiClient\Repositories\AuthenticationRepository;
+
+$authRepository = new AuthenticationRepository();
+$request = $authRepository->postOAuthAuthentication(new OAuthPayload('username', 'password'));
+
+$tokenResponse = $client->jsonResponse($request);
+$token = $tokenResponse->access_token ?? null;
+```
+
+Subsequent requests can be executed by instantiating the client with the retrieved token or by updating the constructor argument.
+
+### Calling Other Endpoints
+Each repository maps to an API tag and provides helpers to build the corresponding request.
+
+```php
+use Shellrent\VeeamVspcApiClient\Repositories\CompanyRepository;
+
+$companyRepository = new CompanyRepository();
+$request = $companyRepository->getCompanies();
+
+$response = $client->jsonResponse($request);
+```
+
+Repositories accept optional filters and query parameters when executed through `VeeamSPCClient::send()` or `VeeamSPCClient::jsonResponse()`. You can build complex filters using `Filter` and `FilterCollection` helpers located under `Shellrent\VeeamVspcApiClient\Support`.
+
+## OpenAPI Specification
+The official VSPC OpenAPI definition used to generate the SDK is stored in [`openapi/3.5.1/vspc-api.json`](openapi/3.5.1/vspc-api.json). Refer to it for a complete list of available operations, parameters, and payload schemas.
+
+## Contributing
+Contributions are welcome! If you plan to submit a pull request:
+
+1. Fork the repository and create a feature branch.
+2. Follow the existing coding standards (tabs for indentation, camelCase properties).
+3. Update or add documentation when introducing new repositories or payload builders.
+4. Ensure your code builds and, when possible, provide usage examples in the PR description.
+
+## License
+This project is released under the [MIT License](LICENSE.md).

--- a/src/Payloads/AGENTS.md
+++ b/src/Payloads/AGENTS.md
@@ -1,0 +1,14 @@
+# Linee guida per `src/Payloads`
+
+Le classi in questa directory rappresentano i corpi delle richieste (`POST`, `PATCH`, ecc.) descritte nello swagger VSPC.
+
+## Convenzioni
+- Implementa sempre l'interfaccia `Payload` quando disponibile e restituisci `self` dai setter per favorire la composizione fluente.
+- Mantieni i nomi delle proprietà privati con la stessa capitalizzazione usata dallo swagger (es. `Name`, `ResellerUid`).
+- Inizializza i valori di default solo quando documentati dalle specifiche oppure quando il comportamento della console lo richiede; in caso contrario lascia `null`.
+- Documenta i setter con docblock quando il tipo accetta valori eterogenei o quando è utile linkare l'attributo corrispondente nello swagger.
+- Evita logica applicativa complessa: queste classi devono limitarsi a raccogliere i dati e fornire un array serializzabile.
+
+## Serializzazione
+- Se crei nuovi payload assicurati che implementino `jsonSerialize()` oppure un metodo equivalente previsto dall'interfaccia.
+- Quando un campo richiede una struttura annidata, usa array PHP standard rispettando esattamente la struttura definita nello swagger.

--- a/src/Repositories/AGENTS.md
+++ b/src/Repositories/AGENTS.md
@@ -1,0 +1,17 @@
+# Linee guida per `src/Repositories`
+
+Ogni classe in questa cartella rappresenta il client per una categoria di endpoint delle API VSPC.
+
+## Convenzioni
+- Il nome della classe deve corrispondere al tag definito nello swagger (es. `PulseRepository`, `CompanyRepository`).
+- Implementa sempre l'interfaccia `Repository` e definisci `getBaseRoute()` con la radice esatta dello specifico endpoint.
+- Usa i trait `CreateGetRequest`, `CreatePostRequest`, `CreatePatchRequest`, `CreateDeleteRequest` invece di istanziare manualmente `RequestBuilder`.
+- Ogni metodo deve restituire un `RequestBuilder`. L'esecuzione della richiesta resta responsabilità di `VeeamSPCClient` o del chiamante.
+- Quando una rotta richiede path parameters, usa `sprintf()` e mantieni l'ordine esatto come documentato nello swagger.
+- Per query string opzionali usa `$request->query([...])`. Mantieni i nomi dei parametri identici a quelli del file OpenAPI (rispettando maiuscole/minuscole).
+- Conserva i nomi dei metodi con il prefisso HTTP (es. `getAll`, `postCreate`, `patchModify…`, `delete…`) per facilitare la ricerca.
+
+## Note pratiche
+- Se l'endpoint permette filtri o paginazione, documenta l'uso nelle docblock del metodo e, quando necessario, valorizza parametri default coerenti con l'API.
+- In caso di breaking change tra versioni dell'API, valuta se introdurre un nuovo metodo lasciando il precedente deprecato per retrocompatibilità.
+- Ricontrolla sempre `openapi/3.5.1/vspc-api.json` per confermare request body, required fields e possibili valori enumerati.

--- a/src/Support/AGENTS.md
+++ b/src/Support/AGENTS.md
@@ -1,0 +1,9 @@
+# Linee guida per `src/Support`
+
+Queste classi e trait forniscono l'infrastruttura comune (builder HTTP, filtri, helper per le richieste).
+
+- Mantieni il codice minimale: niente dipendenze applicative dalle repository o dai payload.
+- I trait `Create*Request` devono restare privi di logica extra; si limitano a costruire il path a partire da `getBaseRoute()` e dal segmento passato.
+- `RequestBuilder` è responsabile della composizione dell'oggetto PSR-7: se servono nuove feature (ad es. header custom, body JSON) aggiungi metodi dedicati che rispettino l'approccio fluent usato da `query()` e `filter()`.
+- I filtri (`Filter`, `FilterCollection`, `FilterConnection`) devono serializzarsi secondo il formato JSON previsto dall'API. Aggiorna i docblock quando introduci nuove operazioni o parametri.
+- Quando modifichi URL o query builder, verifica sempre l'impatto sulle repository esistenti.


### PR DESCRIPTION
## Summary
- rename the OpenAPI specification file to vspc-api.json to align with repository instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e69b262a4c832e8776b4f3331ea6e9